### PR TITLE
refactor(layout): switch hero scroll to document scroll and apply global scroll tweaks

### DIFF
--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -7,7 +7,7 @@ import Nav from '../components/Nav.astro';
   <div class="flex w-full min-h-screen justify-center">
     <Nav />
     <div class="flex flex-row w-full justify-center">
-      <main class="w-full mx-auto overflow-y-auto">
+      <main class="w-full min-h-screen mx-auto">
         <slot />
       </main>
     </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,5 +30,8 @@ const base = import.meta.env.PUBLIC_BASE_URL;
     padding: 0;
     width: 100%;
     height: 100%;
+    scroll-behavior: smooth;
+    overscroll-behavior-y: none;
+    scrollbar-gutter: stable;
   }
 </style>


### PR DESCRIPTION
### Summary
This PR tunes the global layout to rely on the document scroll for the hero section and updates scroll-related behavior across pages.

### Details
- Remove nested overflow container in the main area by dropping overflow-y-auto on IndexPage.astro
- Extend the Layout.astro style block to enable document-level smooth scrolling and stable scrollbar behavior
- Ensure window-based scroll listeners (e.g., Nav.astro) continue to receive events with document scroll
- Preserve full-width/height layouts using existing utilities like min-h-screen
- Browsers without scroll-snap simply scroll normally; users get a smoother and more consistent experience